### PR TITLE
Add Vietnamese (vi) and Indonesian (id) locale support

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -1,7 +1,7 @@
 import { siteConfig } from "./site-config";
 
 export const defaultLocale = "en";
-export const translatedLocales = ["zh", "ru", "es", "fr", "it", "el"];
+export const translatedLocales = ["zh", "ru", "es", "fr", "it", "el", "vi", "id"];
 export const supportedLocales = [defaultLocale, ...translatedLocales];
 
 export const localeOptions = [
@@ -12,6 +12,8 @@ export const localeOptions = [
   { code: "fr", label: "Français", shortLabel: "FR" },
   { code: "it", label: "Italiano", shortLabel: "IT" },
   { code: "el", label: "Ελληνικά", shortLabel: "EL" },
+  { code: "vi", label: "Tiếng Việt", shortLabel: "VI" },
+  { code: "id", label: "Bahasa Indonesia", shortLabel: "ID" },
 ];
 
 export const routePaths = [
@@ -370,6 +372,122 @@ const dictionaries = {
       statusUncorrected: "Dominante colore: non corretta",
       statusAuto: "Dominante colore: corretta automaticamente",
       statusManual: "Dominante colore: corretta da campione",
+    },
+  },
+  vi: {
+    htmlLang: "vi",
+    languageLabel: "Ngôn ngữ",
+    site: {
+      titleSuffix: "Trình xem phim âm bản trực tuyến",
+      description:
+        "Trình xem phim âm bản trực tuyến miễn phí. Sử dụng camera điện thoại hoặc laptop để chuyển đổi phim âm bản thành ảnh dương bản theo thời gian thực — không tải lên, không máy quét, không cần cài đặt.",
+    },
+    nav: {
+      homeAria: "Trang chủ Negative Viewer",
+      primaryAria: "Điều hướng chính",
+      howToUse: "Cách sử dụng",
+      guides: "Hướng dẫn",
+      faq: "FAQ",
+      about: "Giới thiệu",
+    },
+    footer: {
+      tagline:
+        "Công cụ miễn phí trên trình duyệt để xem trước phim âm bản theo thời gian thực.",
+      tool: "Công cụ",
+      openViewer: "Mở trình xem",
+      howToUse: "Cách sử dụng",
+      faq: "FAQ",
+      guides: "Hướng dẫn",
+      filmNegatives: "Tìm hiểu về phim âm bản",
+      digitize35mm: "Số hóa 35mm tại nhà",
+      filmVsDigital: "Phim và kỹ thuật số",
+      about: "Giới thiệu",
+      aboutSite: "Về trang web này",
+      builtBy: "Được tạo bởi",
+      at: "tại",
+    },
+    viewer: {
+      insecureNotice:
+        "Truy cập camera yêu cầu HTTPS. Mở trang này qua HTTPS hoặc localhost để sử dụng trình xem trực tiếp.",
+      cameraUnsupported: "Trình duyệt này không hỗ trợ truy cập camera.",
+      cameraError:
+        "Không thể khởi động camera. Đảm bảo bạn đã cấp quyền và đang sử dụng HTTPS.",
+      videoAria: "Luồng camera trực tiếp để chuyển đổi phim âm bản",
+      canvasAria: "Xem trước ảnh đã xử lý sau khi đảo ngược màu âm bản",
+      placeholder: "Xem trước camera sẽ xuất hiện ở đây.",
+      placeholderSub:
+        "Video của bạn không bao giờ rời khỏi thiết bị này — tất cả xử lý diễn ra trong trình duyệt.",
+      live: "● Trực tiếp",
+      startCamera: "▶ Bật camera",
+      savePhoto: "Lưu ảnh",
+      openConverter: "Chuyển đổi tệp",
+      openConverterAria: "Xử lý âm bản đã lưu với Negative Converter",
+      sampleBase: "Lấy mẫu nền",
+      tapOrangeFilm: "Chạm vào nền cam…",
+      resetColorCast: "Đặt lại cân bằng màu",
+      fullscreen: "Toàn màn hình",
+      exitFullscreen: "Thoát toàn màn hình",
+      statusUncorrected: "Cân bằng màu: chưa chỉnh",
+      statusAuto: "Cân bằng màu: đã chỉnh tự động",
+      statusManual: "Cân bằng màu: đã chỉnh theo mẫu",
+    },
+  },
+  id: {
+    htmlLang: "id",
+    languageLabel: "Bahasa",
+    site: {
+      titleSuffix: "Penampil Negatif Film Online",
+      description:
+        "Penampil negatif film online gratis. Gunakan kamera ponsel atau laptop untuk mengubah negatif film menjadi positif secara real-time — tanpa unggah, tanpa pemindai, tanpa instalasi.",
+    },
+    nav: {
+      homeAria: "Beranda Negative Viewer",
+      primaryAria: "Navigasi utama",
+      howToUse: "Cara menggunakan",
+      guides: "Panduan",
+      faq: "FAQ",
+      about: "Tentang",
+    },
+    footer: {
+      tagline:
+        "Alat gratis berbasis browser untuk melihat pratinjau negatif film secara real-time.",
+      tool: "Alat",
+      openViewer: "Buka penampil",
+      howToUse: "Cara menggunakan",
+      faq: "FAQ",
+      guides: "Panduan",
+      filmNegatives: "Penjelasan negatif film",
+      digitize35mm: "Digitalisasi 35mm di rumah",
+      filmVsDigital: "Film vs. digital",
+      about: "Tentang",
+      aboutSite: "Tentang situs ini",
+      builtBy: "Dibuat oleh",
+      at: "di",
+    },
+    viewer: {
+      insecureNotice:
+        "Akses kamera memerlukan HTTPS. Buka halaman ini melalui HTTPS atau localhost untuk menggunakan penampil langsung.",
+      cameraUnsupported: "Browser ini tidak mendukung akses kamera.",
+      cameraError:
+        "Tidak dapat memulai kamera. Pastikan Anda memberikan izin dan menggunakan HTTPS.",
+      videoAria: "Umpan kamera langsung untuk konversi negatif film",
+      canvasAria: "Pratinjau gambar yang diproses setelah inversi warna negatif",
+      placeholder: "Pratinjau kamera akan muncul di sini.",
+      placeholderSub:
+        "Video Anda tidak pernah meninggalkan perangkat ini — semua pemrosesan berjalan di browser.",
+      live: "● Langsung",
+      startCamera: "▶ Mulai kamera",
+      savePhoto: "Simpan foto",
+      openConverter: "Konversi file",
+      openConverterAria: "Proses negatif tersimpan dengan Negative Converter",
+      sampleBase: "Sampel dasar",
+      tapOrangeFilm: "Ketuk film oranye…",
+      resetColorCast: "Reset warna",
+      fullscreen: "Layar penuh",
+      exitFullscreen: "Keluar layar penuh",
+      statusUncorrected: "Warna: belum dikoreksi",
+      statusAuto: "Warna: dikoreksi otomatis",
+      statusManual: "Warna: dikoreksi sampel",
     },
   },
   el: {

--- a/lib/localized-content.js
+++ b/lib/localized-content.js
@@ -2892,6 +2892,1004 @@ export const localizedPages = {
       },
     },
   },
+  vi: {
+    home: {
+      metaTitle:
+        "Trình xem phim âm bản trực tuyến - Chuyển đổi âm bản thành dương bản trong trình duyệt",
+      metaDescription:
+        "Trình xem phim âm bản trực tuyến miễn phí. Sử dụng camera điện thoại hoặc laptop để xem trước âm bản 35mm, 120 và 4×5 dưới dạng dương bản theo thời gian thực, không tải lên, không máy quét, không cài đặt.",
+      eyebrow: "Miễn phí · Trong trình duyệt · Không tải lên",
+      title:
+        "Trình xem phim âm bản trực tuyến, hiển thị dương bản theo thời gian thực",
+      lede:
+        "Đặt phim âm bản trước camera điện thoại hoặc laptop. Negative Viewer đảo ngược màu sắc theo thời gian thực trong trình duyệt để bạn xem nhanh các khung hình 35mm, 120 và 4×5 — không cần máy quét, không cần ứng dụng, không tải ảnh lên.",
+      afterLede: {
+        before: "Mới sử dụng lần đầu? Đọc ",
+        guide: "hướng dẫn 30 giây",
+        middle: " hoặc xem ",
+        faq: "FAQ",
+        after: ".",
+      },
+      negativeConverterCta: {
+        eyebrow: "Dành cho tệp có sẵn",
+        title: "Đã chụp hoặc quét âm bản của bạn?",
+        text: "Sử dụng Negative Converter khi bạn muốn làm việc với tệp hình ảnh, xử lý hàng loạt khung hình hoặc xuất dương bản hoàn chỉnh sau khi xem nhanh.",
+        linkText: "Xử lý tệp",
+      },
+      whatTitle: "Công cụ này làm được gì",
+      whatParagraphs: [
+        "Phim âm bản lưu hình ảnh với màu sắc bị đảo ngược: da sáng trở nên tối, bầu trời xanh chuyển thành cam, và vùng tối trong suốt hơn. Để xem ảnh thực, cần đảo ngược từng pixel — đó là điều máy quét làm, và cũng là điều trang web này thực hiện theo thời gian thực.",
+        "Bạn không nhất thiết cần máy quét. Với đèn nền đồng đều — như màn hình điện thoại hiển thị màu trắng — một cuộn phim và thiết bị có camera chạy trình duyệt hiện đại, hãy nhấn bắt đầu, hướng camera vào phim và xem ảnh dương bản.",
+      ],
+      reasonsTitle: "Tại sao nên dùng Negative Viewer",
+      features: [
+        {
+          title: "Quyền riêng tư",
+          text: "Khung hình được xử lý trên thiết bị của bạn qua Canvas API. Video và pixel không rời khỏi trình duyệt.",
+        },
+        {
+          title: "Miễn phí mãi mãi",
+          text: "Không đăng ký, không dùng thử, không giới hạn. Trang web được hỗ trợ bởi quảng cáo nhẹ, không phải dữ liệu của bạn.",
+        },
+        {
+          title: "Đa thiết bị",
+          text: "Điện thoại, máy tính bảng, laptop, Chromebook hoặc iPad — chỉ cần trình duyệt hiện đại có thể yêu cầu quyền camera.",
+        },
+        {
+          title: "Xem ngay lập tức",
+          text: "Hình ảnh dương bản hiển thị ở tốc độ khung hình camera, bạn có thể quét qua cả cuộn phim trong vài giây.",
+        },
+        {
+          title: "Lưu một chạm",
+          text: "Nhấn lưu ảnh để tải khung hình hiện tại dưới dạng PNG, tiện cho ghi chú nhanh hoặc chia sẻ ảnh tham khảo.",
+        },
+        {
+          title: "Thiết kế cho người dùng phim",
+          text: "Dành cho nhiếp ảnh gia phim, người lưu trữ và bất kỳ ai tìm thấy hộp phim âm bản gia đình.",
+        },
+      ],
+      stepsTitle: "Ba bước để bắt đầu",
+      steps: [
+        {
+          title: "Chuẩn bị đèn nền đồng đều",
+          text: "Mở ảnh trắng trên điện thoại, máy tính bảng hoặc màn hình khác ở độ sáng tối đa. Đèn xem phim nhỏ cũng hoạt động tốt.",
+        },
+        {
+          title: "Đặt phim sát nguồn sáng",
+          text: "Giữ phim phẳng, mặt nhũ tương hướng về camera, càng gần đèn nền càng tốt để giảm phản xạ.",
+        },
+        {
+          title: "Bật camera và căn chỉnh",
+          text: "Cho phép trình duyệt truy cập camera, điều chỉnh khoảng cách để một khung hình lấp đầy màn hình, lưu PNG khi cần.",
+        },
+      ],
+      deeperGuide: {
+        before: "Để biết thêm về lấy nét, hiệu chỉnh nền cam và xử lý cả cuộn, hãy đọc ",
+        link: "hướng dẫn đầy đủ",
+        after: ".",
+      },
+      faqTitle: "Câu hỏi thường gặp",
+      faqs: [
+        {
+          q: "Trình xem phim âm bản trực tuyến này có thực sự miễn phí không?",
+          a: "Có. Negative Viewer miễn phí sử dụng, không cần tài khoản và chạy hoàn toàn trong trình duyệt. Quá trình xử lý hình ảnh diễn ra trên thiết bị của bạn, không tải video lên.",
+        },
+        {
+          q: "Hỗ trợ những loại phim âm bản nào?",
+          a: "Cả phim màu và đen trắng đều hoạt động, bao gồm 35mm, 120, 4×5, APS, 110 và các định dạng cũ khác có thể chiếu sáng từ phía sau.",
+        },
+        {
+          q: "Có cần cài đặt phần mềm không?",
+          a: "Không. Đây là ứng dụng web hoạt động trong Chrome, Edge, Safari và Firefox trên điện thoại, máy tính bảng và máy tính.",
+        },
+        {
+          q: "Có hiệu chỉnh nền cam của phim màu không?",
+          a: "Công cụ thực hiện đảo ngược RGB thời gian thực và có thể giảm lệch màu bằng cách lấy mẫu nền, nhưng ảnh cuối cùng nên được tinh chỉnh trong trình chỉnh sửa ảnh.",
+        },
+        {
+          q: "Có thể xử lý tệp âm bản đã chụp hoặc quét không?",
+          a: "Có. Negative Viewer phù hợp nhất để xem trực tiếp qua camera. Nếu bạn đã có tệp hình ảnh, hãy mở Negative Converter để chuyển đổi và xuất dương bản.",
+        },
+      ],
+      moreFaq: {
+        before: "Thêm câu trả lời tại ",
+        link: "trang FAQ đầy đủ",
+        after: ".",
+      },
+      readNextTitle: "Đọc thêm",
+      readNext: [
+        {
+          title: "Tìm hiểu về phim âm bản",
+          href: "/guides/film-negatives",
+          text: "Phim âm bản là gì, tại sao có màu cam và cách đọc chúng.",
+        },
+        {
+          title: "Số hóa 35mm tại nhà",
+          href: "/guides/digitize-35mm",
+          text: "Bốn phương pháp số hóa phim 35mm tại nhà và khi nào nên chọn từng phương pháp.",
+        },
+        {
+          title: "Phim và nhiếp ảnh kỹ thuật số",
+          href: "/guides/film-vs-digital",
+          text: "So sánh thực tế về chi phí, độ phân giải, dải tương phản động và phong cách hình ảnh.",
+        },
+      ],
+    },
+    howTo: {
+      metaTitle: "Cách sử dụng Negative Viewer - Hướng dẫn từng bước",
+      metaDescription:
+        "Hướng dẫn từng bước để xem phim âm bản dưới dạng dương bản trong trình duyệt: đèn nền, căn khung, lấy nét, xử lý lệch màu và lưu PNG.",
+      title: "Cách sử dụng Negative Viewer",
+      readTime: "3 phút",
+      intro:
+        "Phiên bản ngắn: mở Negative Viewer, đặt phim âm bản lên đèn nền đồng đều, hướng camera vào phim và nhấn bắt đầu. Trang web đảo ngược màu sắc theo thời gian thực và thường mất chưa đến một phút để thiết lập.",
+      callout: {
+        label: "Bắt đầu ngay:",
+        text: "Trình xem trực tiếp có trên trang chủ và được nhúng bên dưới hướng dẫn này.",
+      },
+      steps: [
+        {
+          name: "Chuẩn bị đèn nền đồng đều",
+          text: "Màn hình trắng trên điện thoại, máy tính bảng hoặc màn hình thứ hai ở độ sáng tối đa. Đèn xem phim nhỏ cũng được, miễn là ánh sáng đồng đều.",
+        },
+        {
+          name: "Đặt phim sát nguồn sáng",
+          text: "Giữ phim phẳng, mặt nhũ tương hướng về camera. Ấn nhẹ các cạnh giúp phim 35mm không bị cong.",
+        },
+        {
+          name: "Mở trình xem và cho phép camera",
+          text: "Tải trang trên thiết bị bạn dùng để chụp, chấp nhận yêu cầu quyền camera trong trình duyệt.",
+        },
+        {
+          name: "Căn khung và lấy nét",
+          text: "Di chuyển thiết bị sao cho một khung hình lấp đầy vùng xem trước. Trên điện thoại, chạm để khóa nét.",
+        },
+        {
+          name: "Kiểm tra màu đèn nền",
+          text: "Nếu ảnh quá xanh hoặc quá cam, thường là do đèn nền chứ không phải do phim.",
+        },
+        {
+          name: "Lưu khung hình mong muốn",
+          text: "Nhấn lưu ảnh để tải bản xem trước dương bản hiện tại dưới dạng PNG.",
+        },
+      ],
+      tipsTitle: "Mẹo để có hình ảnh sắc nét hơn",
+      tips: [
+        "Ưu tiên camera sau — thường có độ phân giải và ống kính tốt hơn.",
+        "Dùng chân máy nhỏ, chồng sách hoặc giá đỡ để giảm rung tay.",
+        "Làm sạch phim trước khi xem — bụi thành chấm trắng trên ảnh dương bản.",
+        "Giữ ống kính song song với phim để tránh méo phối cảnh.",
+        "Màu sắc cuối cùng nên được tinh chỉnh trong Photos, Lightroom hoặc trình chỉnh sửa khác.",
+      ],
+      browserTitle: "Tương thích trình duyệt",
+      browserHeaders: ["Trình duyệt", "Camera", "Ghi chú"],
+      browserRows: [
+        ["Chrome trên desktop và Android", "Hỗ trợ", "Cần HTTPS; quyền được lưu theo trang."],
+        ["Safari trên iOS và macOS", "Hỗ trợ", "Đôi khi cần cấp lại quyền mỗi lần truy cập."],
+        ["Edge", "Hỗ trợ", "Hoạt động gần giống Chrome."],
+        ["Firefox", "Hỗ trợ", "Tiện khi có nhiều camera kết nối."],
+        ["Trình duyệt trong ứng dụng", "Thường bị chặn", "Mở trực tiếp trong Safari hoặc Chrome."],
+      ],
+      problemsTitle: "Sự cố thường gặp",
+      problems: [
+        {
+          title: "Camera không khởi động",
+          text: "Kiểm tra HTTPS và cấp lại quyền camera trong thanh địa chỉ hoặc cài đặt trình duyệt.",
+        },
+        {
+          title: "Hình ảnh quá tối",
+          text: "Tăng độ sáng đèn nền lên tối đa và loại bỏ các vật xung quanh lọt vào khung hình.",
+        },
+        {
+          title: "Màu sắc trông không đúng",
+          text: "Phim màu có nền cam, sau khi đảo ngược thường tạo ra sắc xanh nhẹ — điều này bình thường và có thể điều chỉnh cân bằng trắng sau.",
+        },
+      ],
+      tryTitle: "Dùng thử ngay",
+      cta: {
+        text: "Vẫn còn thắc mắc?",
+        link: "Mở FAQ →",
+      },
+    },
+    faq: {
+      metaTitle: "FAQ Negative Viewer - Câu hỏi thường gặp về chuyển đổi phim âm bản",
+      metaDescription:
+        "Câu hỏi thường gặp về trình xem phim âm bản trên trình duyệt: quyền riêng tư, định dạng hỗ trợ, màu sắc, trình duyệt và lưu kết quả.",
+      title: "Câu hỏi thường gặp",
+      intro:
+        "Dưới đây là những câu hỏi phổ biến nhất. Nếu bạn mới sử dụng, hãy bắt đầu với",
+      ctaText: "Sẵn sàng dùng thử?",
+      ctaLink: "Mở trình xem →",
+      negativeConverterCta: {
+        eyebrow: "Dành cho tệp có sẵn",
+        title: "Đã chụp hoặc quét âm bản của bạn?",
+        text: "Sử dụng Negative Converter khi bạn muốn làm việc với tệp hình ảnh, xử lý hàng loạt khung hình hoặc xuất dương bản hoàn chỉnh sau khi xem nhanh.",
+        linkText: "Mở Negative Converter",
+      },
+      faqs: [
+        {
+          q: "Trình xem phim âm bản là gì?",
+          a: "Đây là công cụ đảo ngược màu sắc của phim âm bản để hiển thị ảnh gốc dưới dạng dương bản. Theo cách truyền thống, bạn cần đèn xem phim và kính lúp; công cụ trực tuyến sử dụng camera thiết bị và phần mềm đảo ngược để hiển thị dương bản theo thời gian thực.",
+        },
+        {
+          q: "Negative Viewer có thực sự miễn phí không?",
+          a: "Có. Trang web miễn phí từ khi ra mắt, không cần tài khoản, không dùng thử, không tính phí theo ảnh. Quảng cáo nhẹ hỗ trợ chi phí hosting.",
+        },
+        {
+          q: "Trang web có tải lên video hoặc ảnh từ camera của tôi không?",
+          a: "Không. Mỗi khung hình được xử lý cục bộ trong trình duyệt qua HTML Canvas API. Luồng video không rời khỏi thiết bị của bạn.",
+        },
+        {
+          q: "Hỗ trợ những định dạng phim nào?",
+          a: "Bất kỳ phim âm bản nào có thể chiếu sáng từ phía sau, bao gồm 35mm màu và đen trắng, 120, 4×5 và 8×10, APS, Disc và 110.",
+        },
+        {
+          q: "Có hoạt động với phim slide hoặc phim dương bản không?",
+          a: "Phim slide vốn đã là dương bản. Đảo ngược sẽ khiến chúng trông giống âm bản, vì vậy chế độ này thường không cần cho slide.",
+        },
+        {
+          q: "Tại sao bản xem trước có sắc xanh hoặc lam?",
+          a: "Phim màu có nền cam, sau khi đảo ngược tạo ra sắc xanh nhẹ. Điều này bình thường và có thể điều chỉnh bằng cân bằng trắng trong bất kỳ trình chỉnh sửa ảnh nào.",
+        },
+        {
+          q: "Nên dùng loại đèn nền nào?",
+          a: "Ánh sáng trắng, sáng và đồng đều là tốt nhất. Các lựa chọn phổ biến: màn hình điện thoại hoặc máy tính bảng hiển thị trắng, đèn xem phim nhỏ, đèn bàn với giấy khuếch tán, hoặc ánh sáng cửa sổ ngày nhiều mây.",
+        },
+        {
+          q: "Tại sao camera không khởi động?",
+          a: "Ba lý do phổ biến: đã từ chối quyền camera trước đó, đang ở trong trình duyệt nhúng của ứng dụng, hoặc không dùng HTTPS.",
+        },
+        {
+          q: "Làm thế nào để lưu ảnh?",
+          a: "Khi camera đang chạy, nhấn nút lưu ảnh. Trình duyệt tải xuống bản xem trước hiện tại dưới dạng PNG.",
+        },
+        {
+          q: "Có thể xử lý cả cuộn phim cùng lúc không?",
+          a: "Có thể xử lý thủ công. Trải toàn bộ dải phim lên đèn nền, di chuyển từng khung hình vào vùng xem và nhấn lưu ảnh.",
+        },
+        {
+          q: "Có thể xử lý tệp âm bản đã chụp hoặc quét không?",
+          a: "Có. Negative Viewer phù hợp nhất để xem trực tiếp qua camera. Nếu bạn đã có tệp hình ảnh, hãy mở Negative Converter để chuyển đổi và xuất dương bản.",
+        },
+        {
+          q: "So với dùng đường cong đảo ngược trong Lightroom thì thế nào?",
+          a: "Lightroom hoặc quy trình RAW phù hợp hơn cho kết quả cuối cùng, vì xử lý ảnh tĩnh với độ sâu bit cao. Negative Viewer nhanh hơn nhiều — bạn thấy ảnh dương bản ngay khi đang nhìn vào phim, rất tiện để phân loại ảnh chưa biết.",
+        },
+        {
+          q: "Có hoạt động trên Chromebook hoặc iPad không?",
+          a: "Có. Miễn là thiết bị có camera hoạt động và hỗ trợ API getUserMedia, Chromebook, iPad, điện thoại và máy tính bảng đều hoạt động.",
+        },
+        {
+          q: "Nên đặt phim theo hướng nào?",
+          a: "Thường thì mặt nhũ tương mờ hướng về camera, mặt bóng hướng về đèn nền. Nếu xem trước bị lật, hãy thử mặt còn lại.",
+        },
+        {
+          q: "Các tính năng mới có bị tính phí không?",
+          a: "Trình xem lõi sẽ luôn miễn phí. Các bổ sung trong tương lai như loại bỏ nền cam tốt hơn hoặc hiệu chỉnh phối cảnh cũng sẽ ưu tiên triển khai phía máy khách.",
+        },
+        {
+          q: "Tôi có phản hồi hoặc đề xuất, gửi ở đâu?",
+          a: "Cách nhanh nhất là mở issue trên kho GitHub được liên kết ở trang Giới thiệu. Mọi phản hồi đều được đọc.",
+        },
+      ],
+    },
+    about: {
+      metaTitle: "Giới thiệu Negative Viewer - Công cụ phim âm bản trực tuyến bảo vệ quyền riêng tư",
+      metaDescription:
+        "Tìm hiểu về Negative Viewer: tại sao nó tồn tại, cách hoạt động, cam kết quyền riêng tư và công nghệ đằng sau trình chuyển đổi phim âm bản trên trình duyệt.",
+      title: "Giới thiệu về Negative Viewer",
+      sections: [
+        {
+          title: "Tại sao công cụ này tồn tại",
+          paragraphs: [
+            "Nhiều người có phim âm bản nhưng không có máy quét phim. Máy quét chuyên dụng đắt tiền, mỗi lần quét mất thời gian và thường chỉ dùng vài lần mỗi năm. Trong khi đó, điện thoại trong túi bạn đã có camera đủ tốt để xem trước phim âm bản — chỉ thiếu phần mềm đảo ngược hình ảnh theo thời gian thực.",
+            "Negative Viewer chính là phần mềm đó. Nó chạy dưới dạng ứng dụng web nhỏ nên không cần cài đặt. Đặt phim âm bản lên bất kỳ đèn nền nào, hướng điện thoại vào và hình ảnh dương bản xuất hiện trên màn hình.",
+          ],
+        },
+        {
+          title: "Cách hoạt động",
+          paragraphs: [
+            "Công cụ yêu cầu quyền camera qua Web getUserMedia API tiêu chuẩn. Mỗi khung hình video được vẽ lên HTML Canvas, trừ các kênh đỏ, lục, lam từ 255 — phép đảo ngược màu tiêu chuẩn — rồi vẽ lại lên màn hình ở tốc độ khung hình camera.",
+            "Không có mạng nơ-ron, không xử lý đám mây, không tải lên. Mã lõi nhỏ và toàn bộ mã nguồn được lưu trong kho của dự án.",
+          ],
+        },
+        {
+          title: "Cam kết quyền riêng tư",
+          list: [
+            "Không tải lên luồng camera. Pixel chỉ được xử lý trong trình duyệt của bạn và trang web không có điểm cuối nhận dữ liệu video hoặc ảnh.",
+            "Không yêu cầu tài khoản, email hoặc vân tay. Chúng tôi chỉ thu thập số liệu phân tích trang ẩn danh để quyết định cải tiến gì.",
+            "Quảng cáo được hiển thị rõ ràng. Trang web sử dụng Google AdSense; kiểm soát quảng cáo có sẵn trong Google Ad Settings.",
+          ],
+        },
+        {
+          title: "Ai bảo trì",
+          paragraphs: [
+            "Negative Viewer được tạo và bảo trì bởi một nhà phát triển tại Tokugai. Dự án bắt đầu chỉ để sắp xếp một hộp phim âm bản gia đình và trở thành trang công khai sau khi bạn bè đề xuất.",
+          ],
+        },
+        {
+          title: "Lộ trình",
+          list: [
+            "Loại bỏ nền cam phim màu tùy chọn trong trình duyệt.",
+            "Cắt và xoay trước khi lưu để PNG gần với trạng thái có thể chia sẻ hơn.",
+            "Tùy chọn xuất đã xóa EXIF cho các bộ sưu tập lưu trữ nhạy cảm.",
+          ],
+        },
+      ],
+      cta: {
+        text: "Đã sẵn sàng?",
+        link: "Mở trình xem →",
+      },
+    },
+    guides: {
+      filmNegatives: {
+        metaTitle: "Tìm hiểu phim âm bản: Cách hoạt động, nhận dạng và xem",
+        metaDescription:
+          "Hướng dẫn thực tế về phim âm bản: tại sao có màu cam, cách phân biệt 35mm/120/khổ lớn, cách đọc khung hình và xem dương bản không cần máy quét.",
+        title: "Tìm hiểu phim âm bản: Cách hoạt động và cách xem",
+        readTime: "6 phút",
+        intro:
+          "Phim âm bản là một tấm nhựa trong suốt ghi lại cảnh đã đảo ngược: vùng sáng tối đi, màu sắc chuyển thành màu bổ sung. Để xem ảnh thực, cần đảo ngược hình ảnh.",
+        sections: [
+          {
+            title: "Phim âm bản là gì",
+            paragraphs: [
+              "Phim âm bản gồm lớp nhũ tương nhạy sáng trên đế nhựa. Sau khi tráng, vùng sáng của cảnh trở nên đậm đặc hơn, vùng tối trong suốt hơn.",
+              "Âm bản là bản gốc. Bạn có thể in hoặc quét nhiều lần, thay đổi cắt cúp, tương phản và màu sắc mỗi lần.",
+            ],
+          },
+          {
+            title: "Tại sao phim màu có màu cam",
+            paragraphs: [
+              "Nền cam là mặt nạ màu, bù đắp cho sự không hoàn hảo của thuốc nhuộm phim khi in quang học. Khi đảo ngược kỹ thuật số, nó thường tạo ra sắc xanh lam nhẹ.",
+            ],
+            list: [
+              "Phim âm bản màu thường cần điều chỉnh cân bằng trắng sau khi đảo ngược.",
+              "Phim đen trắng không có mặt nạ cam.",
+              "Phim slide/dương bản đã là dương bản, không cần đảo ngược.",
+            ],
+          },
+          {
+            title: "Các định dạng phổ biến",
+            table: {
+              headers: ["Định dạng", "Kích thước khung", "Ứng dụng phổ biến"],
+              rows: [
+                ["35mm", "24 × 36 mm", "Máy ảnh gia đình và người dùng phim hiện đại"],
+                ["120", "6×4.5 đến 6×9", "Chân dung, cưới, studio"],
+                ["4×5", "102 × 127 mm", "Phong cảnh và kiến trúc"],
+                ["APS / 110", "Nhỏ hơn 35mm", "Máy ảnh nhỏ gọn"],
+              ],
+            },
+          },
+          {
+            title: "Cách xem dương bản với chi phí thấp",
+            table: {
+              headers: ["Phương pháp", "Chi phí", "Phù hợp nhất cho"],
+              rows: [
+                ["Negative Viewer + màn hình điện thoại", "Miễn phí", "Xem nhanh và phân loại"],
+                ["Ảnh điện thoại + đảo ngược trong app", "Miễn phí", "Ảnh để gửi và chia sẻ"],
+                ["Máy ảnh + ống kính macro + đèn xem phim", "Chi phí thấp nếu có sẵn thiết bị", "Chất lượng lưu trữ"],
+                ["Máy quét phẳng", "$250–$400", "Hàng loạt và khổ trung"],
+              ],
+            },
+          },
+          {
+            title: "Bảo quản phim âm bản",
+            list: [
+              "Giữ phim ở nơi mát, khô và tối.",
+              "Sử dụng túi bảo quản polyethylene, polypropylene hoặc polyester.",
+              "Chỉ chạm vào cạnh phim để tránh làm xước lớp nhũ tương.",
+            ],
+          },
+        ],
+        cta: {
+          text: "Dùng thử với phim âm bản của bạn:",
+          link: "Mở trình xem →",
+        },
+      },
+      digitize35mm: {
+        metaTitle: "Cách số hóa phim âm bản 35mm tại nhà",
+        metaDescription:
+          "So sánh bốn cách số hóa phim âm bản 35mm tại nhà: xem trên trình duyệt, chụp điện thoại rồi đảo ngược, chụp bằng máy ảnh DSLR và máy quét phẳng.",
+        title: "Cách số hóa phim 35mm tại nhà",
+        readTime: "6 phút",
+        intro:
+          "Cách nhanh nhất để biết trong phim cũ có gì là mở trình xem trên trình duyệt. Với chất lượng tốt hơn, chụp ảnh tĩnh độ phân giải cao bằng điện thoại hoặc máy ảnh với ống kính macro.",
+        sections: [
+          {
+            title: "Lựa chọn nhanh",
+            table: {
+              headers: ["Mục tiêu", "Phương pháp", "Lý do"],
+              rows: [
+                ["Chỉ muốn xem có gì", "Trình xem trên trình duyệt", "Ngay lập tức, miễn phí, không cần thiết lập"],
+                ["Chia sẻ ảnh gia đình", "Ảnh điện thoại + đảo ngược", "Đủ tốt cho màn hình"],
+                ["Chất lượng lưu trữ", "DSLR / mirrorless scan", "RAW và chi tiết cao"],
+                ["Hàng trăm khung hình", "Máy quét phẳng", "Khay giữ phim và xử lý hàng loạt"],
+              ],
+            },
+          },
+          {
+            title: "Phương pháp 1 — Trình xem trên trình duyệt",
+            paragraphs: [
+              "Đặt phim trên đèn nền đồng đều, cho phép camera và xem dương bản theo thời gian thực. Đây là cách tốt nhất để phân loại nhanh cả cuộn phim.",
+            ],
+          },
+          {
+            title: "Phương pháp 2 — Chụp bằng điện thoại",
+            paragraphs: [
+              "Chụp phim được chiếu sáng ở độ phân giải đầy đủ của điện thoại, sau đó đảo ngược trong Snapseed, Lightroom Mobile hoặc trình chỉnh sửa khác. Chất lượng thường cao hơn khung hình video.",
+            ],
+          },
+          {
+            title: "Phương pháp 3 — Máy ảnh và ống kính macro",
+            paragraphs: [
+              "Máy ảnh kỹ thuật số trên chân máy hoặc giá chụp cho kết quả tốt nhất. Chụp RAW, khóa cân bằng trắng và đảo ngược trong trình chỉnh sửa.",
+            ],
+          },
+          {
+            title: "Lời khuyên chung",
+            list: [
+              "Làm sạch phim trước khi chụp.",
+              "Giữ máy ảnh và phim song song.",
+              "Dùng nguồn sáng có chỉ số hoàn màu tốt.",
+              "Lưu PNG hoặc TIFF làm tệp gốc.",
+            ],
+          },
+        ],
+        cta: {
+          text: "Muốn bắt đầu miễn phí?",
+          link: "Mở Negative Viewer →",
+        },
+      },
+      filmVsDigital: {
+        metaTitle: "Phim và nhiếp ảnh kỹ thuật số: So sánh thực tế",
+        metaDescription:
+          "So sánh phim và nhiếp ảnh kỹ thuật số về độ phân giải, dải tương phản động, chi phí mỗi ảnh, tuổi thọ lưu trữ và cái gọi là 'chất phim'.",
+        title: "Phim và nhiếp ảnh kỹ thuật số: So sánh thực tế",
+        readTime: "5 phút",
+        intro:
+          "Máy ảnh kỹ thuật số hiện đại thường thắng về tiện lợi và chi phí mỗi ảnh, nhưng phim vẫn có giá trị: âm bản gốc bền lâu, kết cấu hạt và nhịp độ chụp có chủ đích từ số ảnh giới hạn.",
+        sections: [
+          {
+            title: "Kết luận nhanh",
+            table: {
+              headers: ["Tình huống", "Gợi ý", "Lý do"],
+              rows: [
+                ["Học và chụp hàng ngày", "Kỹ thuật số", "Phản hồi ngay, chi phí mỗi ảnh gần bằng không"],
+                ["Cưới và sự kiện", "Kỹ thuật số", "Đáng tin cậy, giao hàng nhanh"],
+                ["Chân dung và biên tập", "Cả hai", "Phim cho phong cách, số cho ngân sách"],
+                ["Lưu trữ gia đình dài hạn", "Âm bản + bản sao số", "Âm bản bền, số dễ chia sẻ"],
+              ],
+            },
+          },
+          {
+            title: "Độ phân giải và dải tương phản động",
+            paragraphs: [
+              "Phim màu 35mm thường cho khoảng 12–18 MP chi tiết hữu ích khi quét tốt. Khổ trung và lớn có thể vượt xa con số này.",
+              "Phim màu chịu overexposure tốt, nhưng cảm biến số hiện đại đã đạt hoặc vượt dải tương phản động của nhiều quy trình phim.",
+            ],
+          },
+          {
+            title: "Chi phí mỗi ảnh",
+            paragraphs: [
+              "Máy ảnh số đắt ban đầu nhưng sau đó mỗi ảnh gần như miễn phí. Phim vào cửa rẻ hơn nhưng phim, tráng và quét liên tục phát sinh chi phí.",
+            ],
+          },
+          {
+            title: "Tại sao vẫn có người chụp phim",
+            list: [
+              "Hạt và chuyển tiếp tông màu khác với nhiễu số.",
+              "Số ảnh giới hạn buộc bạn suy nghĩ trước khi bấm máy.",
+              "Âm bản là hiện vật có thể lưu trữ hàng chục năm.",
+            ],
+          },
+        ],
+        cta: {
+          text: "Đang chụp phim?",
+          link: "Mở Negative Viewer →",
+        },
+      },
+    },
+  },
+  id: {
+    home: {
+      metaTitle:
+        "Penampil Negatif Film Online - Ubah Negatif Jadi Positif di Browser",
+      metaDescription:
+        "Penampil negatif film online gratis. Gunakan kamera ponsel atau laptop untuk melihat pratinjau negatif 35mm, 120, dan 4×5 sebagai positif secara real-time, tanpa unggah, tanpa pemindai, tanpa instalasi.",
+      eyebrow: "Gratis · Dalam browser · Tanpa unggah",
+      title:
+        "Penampil negatif film online yang menampilkan positif secara real-time",
+      lede:
+        "Letakkan negatif film di depan kamera ponsel atau laptop. Negative Viewer membalikkan warna secara real-time di browser sehingga Anda bisa meninjau bingkai 35mm, 120, dan 4×5 dengan cepat — tanpa pemindai, tanpa aplikasi, tanpa mengunggah gambar.",
+      afterLede: {
+        before: "Baru pertama kali? Baca ",
+        guide: "panduan 30 detik",
+        middle: " atau buka ",
+        faq: "FAQ",
+        after: ".",
+      },
+      negativeConverterCta: {
+        eyebrow: "Untuk file yang sudah ada",
+        title: "Sudah memotret atau memindai negatif Anda?",
+        text: "Gunakan Negative Converter saat Anda ingin bekerja dengan file gambar, memproses beberapa bingkai sekaligus, atau mengekspor positif jadi setelah melihat pratinjau cepat.",
+        linkText: "Proses file",
+      },
+      whatTitle: "Apa yang dilakukan alat ini",
+      whatParagraphs: [
+        "Negatif film menyimpan gambar dengan warna terbalik: kulit terang tampak gelap, langit biru berubah jingga, dan bayangan lebih transparan. Untuk melihat foto sebenarnya, setiap piksel harus dibalik — itulah yang dilakukan pemindai, dan itulah yang dilakukan halaman web ini secara real-time.",
+        "Anda tidak harus punya pemindai. Dengan cahaya latar yang merata — seperti layar ponsel yang menampilkan putih — satu rol film, dan perangkat berkamera dengan browser modern, tekan mulai, arahkan ke film, dan lihat gambar positifnya.",
+      ],
+      reasonsTitle: "Mengapa menggunakan Negative Viewer",
+      features: [
+        {
+          title: "Privasi bawaan",
+          text: "Bingkai diproses di perangkat Anda melalui Canvas API. Video dan piksel tidak meninggalkan browser.",
+        },
+        {
+          title: "Gratis selamanya",
+          text: "Tanpa daftar, tanpa uji coba, tanpa batas. Situs didukung iklan ringan, bukan data Anda.",
+        },
+        {
+          title: "Lintas perangkat",
+          text: "Ponsel, tablet, laptop, Chromebook, atau iPad — cukup browser modern yang bisa meminta izin kamera.",
+        },
+        {
+          title: "Pratinjau instan",
+          text: "Gambar positif muncul pada kecepatan bingkai kamera, Anda bisa memindai seluruh rol dalam hitungan detik.",
+        },
+        {
+          title: "Simpan sekali ketuk",
+          text: "Tekan simpan foto untuk mengunduh bingkai saat ini sebagai PNG, praktis untuk catatan cepat atau berbagi referensi.",
+        },
+        {
+          title: "Dirancang untuk pengguna film",
+          text: "Untuk fotografer film, pengarsip, dan siapa pun yang menemukan kotak negatif keluarga.",
+        },
+      ],
+      stepsTitle: "Tiga langkah memulai",
+      steps: [
+        {
+          title: "Siapkan cahaya latar merata",
+          text: "Buka gambar putih di ponsel, tablet, atau layar lain dengan kecerahan maksimal. Lightbox kecil juga bisa.",
+        },
+        {
+          title: "Tempelkan negatif ke sumber cahaya",
+          text: "Jaga film tetap datar, sisi emulsi menghadap kamera, sedekat mungkin ke cahaya latar untuk mengurangi pantulan.",
+        },
+        {
+          title: "Mulai kamera dan bidik",
+          text: "Izinkan browser mengakses kamera, sesuaikan jarak hingga satu bingkai memenuhi layar, simpan PNG bila perlu.",
+        },
+      ],
+      deeperGuide: {
+        before: "Untuk detail tentang fokus, koreksi dasar oranye, dan seluruh rol, baca ",
+        link: "panduan lengkap",
+        after: ".",
+      },
+      faqTitle: "Pertanyaan umum",
+      faqs: [
+        {
+          q: "Apakah penampil negatif online ini benar-benar gratis?",
+          a: "Ya. Negative Viewer gratis digunakan, tidak perlu akun, dan berjalan sepenuhnya di browser. Pemrosesan gambar terjadi di perangkat Anda, video tidak diunggah.",
+        },
+        {
+          q: "Negatif apa saja yang didukung?",
+          a: "Negatif warna dan hitam putih, termasuk 35mm, 120, 4×5, APS, 110, dan format lama lainnya yang bisa disinari dari belakang.",
+        },
+        {
+          q: "Perlu instalasi software?",
+          a: "Tidak. Ini aplikasi web yang berjalan di Chrome, Edge, Safari, dan Firefox di ponsel, tablet, dan komputer.",
+        },
+        {
+          q: "Apakah mengoreksi dasar oranye pada film warna?",
+          a: "Alat ini melakukan inversi RGB real-time dan bisa mengurangi pergeseran warna dengan sampel dasar, tapi gambar akhir sebaiknya disempurnakan di editor foto.",
+        },
+        {
+          q: "Bisa memproses file negatif yang sudah difoto atau dipindai?",
+          a: "Ya. Negative Viewer paling cocok untuk pratinjau langsung lewat kamera. Jika Anda sudah punya file gambar, buka Negative Converter untuk mengonversi dan mengekspor positif.",
+        },
+      ],
+      moreFaq: {
+        before: "Lebih banyak jawaban di ",
+        link: "halaman FAQ lengkap",
+        after: ".",
+      },
+      readNextTitle: "Baca selanjutnya",
+      readNext: [
+        {
+          title: "Penjelasan negatif film",
+          href: "/guides/film-negatives",
+          text: "Apa itu negatif, mengapa warnanya oranye, dan cara membacanya.",
+        },
+        {
+          title: "Digitalisasi 35mm di rumah",
+          href: "/guides/digitize-35mm",
+          text: "Empat metode digitalisasi film 35mm di rumah dan kapan memilih masing-masing.",
+        },
+        {
+          title: "Film vs. fotografi digital",
+          href: "/guides/film-vs-digital",
+          text: "Perbandingan praktis tentang biaya, resolusi, rentang dinamis, dan gaya gambar.",
+        },
+      ],
+    },
+    howTo: {
+      metaTitle: "Cara Menggunakan Negative Viewer - Panduan Langkah demi Langkah",
+      metaDescription:
+        "Panduan langkah demi langkah untuk melihat negatif film sebagai positif di browser: cahaya latar, pembingkaian, fokus, penanganan pergeseran warna, dan menyimpan PNG.",
+      title: "Cara Menggunakan Negative Viewer",
+      readTime: "3 menit",
+      intro:
+        "Versi singkat: buka Negative Viewer, letakkan negatif di atas cahaya latar merata, arahkan kamera ke negatif, dan tekan mulai. Situs membalikkan warna secara real-time dan biasanya butuh kurang dari satu menit untuk disiapkan.",
+      callout: {
+        label: "Langsung ke alat:",
+        text: "Penampil langsung ada di halaman utama dan juga disematkan di bawah panduan ini.",
+      },
+      steps: [
+        {
+          name: "Siapkan cahaya latar merata",
+          text: "Layar putih di ponsel, tablet, atau monitor kedua dengan kecerahan maksimal. Lightbox kecil juga boleh, asal cahayanya merata.",
+        },
+        {
+          name: "Tempelkan negatif ke cahaya",
+          text: "Jaga film tetap datar, sisi emulsi menghadap kamera. Menekan perlahan di tepi membantu film 35mm tetap rata.",
+        },
+        {
+          name: "Buka penampil dan izinkan kamera",
+          text: "Muat halaman di perangkat yang Anda gunakan untuk membidik, terima permintaan izin kamera di browser.",
+        },
+        {
+          name: "Bingkai dan fokus",
+          text: "Gerakkan perangkat hingga satu bingkai hampir memenuhi area pratinjau. Di ponsel, ketuk untuk mengunci fokus.",
+        },
+        {
+          name: "Periksa warna cahaya latar",
+          text: "Jika gambar terlalu biru atau terlalu jingga, biasanya penyebabnya adalah cahaya latar, bukan filmnya.",
+        },
+        {
+          name: "Simpan bingkai yang diinginkan",
+          text: "Tekan simpan foto untuk mengunduh pratinjau positif saat ini sebagai PNG.",
+        },
+      ],
+      tipsTitle: "Tips untuk gambar lebih tajam",
+      tips: [
+        "Utamakan kamera belakang — biasanya resolusi dan lensanya lebih baik.",
+        "Gunakan tripod kecil, tumpukan buku, atau penyangga untuk mengurangi goyangan.",
+        "Bersihkan negatif sebelum melihat — debu jadi titik putih di positif.",
+        "Jaga lensa sejajar dengan film untuk menghindari distorsi perspektif.",
+        "Warna akhir sebaiknya disempurnakan di Photos, Lightroom, atau editor lain.",
+      ],
+      browserTitle: "Kompatibilitas browser",
+      browserHeaders: ["Browser", "Kamera", "Catatan"],
+      browserRows: [
+        ["Chrome di desktop dan Android", "Didukung", "Perlu HTTPS; izin disimpan per situs."],
+        ["Safari di iOS dan macOS", "Didukung", "Kadang perlu izin ulang tiap kunjungan."],
+        ["Edge", "Didukung", "Perilaku hampir sama dengan Chrome."],
+        ["Firefox", "Didukung", "Memudahkan pemilihan perangkat jika ada beberapa kamera."],
+        ["Browser dalam aplikasi", "Sering diblokir", "Buka langsung di Safari atau Chrome."],
+      ],
+      problemsTitle: "Masalah umum",
+      problems: [
+        {
+          title: "Kamera tidak mau mulai",
+          text: "Periksa HTTPS dan izinkan ulang kamera di bilah alamat atau pengaturan browser.",
+        },
+        {
+          title: "Gambar terlalu gelap",
+          text: "Naikkan kecerahan cahaya latar ke maksimum dan singkirkan benda di sekitar negatif yang masuk bingkai.",
+        },
+        {
+          title: "Warna terlihat tidak tepat",
+          text: "Film warna memiliki dasar oranye, setelah inversi biasanya menghasilkan semburat biru ringan — ini normal dan bisa disesuaikan dengan white balance.",
+        },
+      ],
+      tryTitle: "Coba sekarang",
+      cta: {
+        text: "Masih ada pertanyaan?",
+        link: "Buka FAQ →",
+      },
+    },
+    faq: {
+      metaTitle: "FAQ Negative Viewer - Pertanyaan Umum Konversi Negatif Online",
+      metaDescription:
+        "Pertanyaan umum tentang penampil negatif film berbasis browser: privasi, format yang didukung, warna, browser, dan menyimpan hasil.",
+      title: "Pertanyaan Umum",
+      intro:
+        "Berikut adalah pertanyaan yang paling sering diajukan. Jika Anda baru, mulailah dengan",
+      ctaText: "Siap mencoba?",
+      ctaLink: "Buka penampil →",
+      negativeConverterCta: {
+        eyebrow: "Untuk file yang sudah ada",
+        title: "Sudah memotret atau memindai negatif Anda?",
+        text: "Gunakan Negative Converter saat Anda ingin bekerja dengan file gambar, memproses beberapa bingkai sekaligus, atau mengekspor positif jadi setelah melihat pratinjau cepat.",
+        linkText: "Buka Negative Converter",
+      },
+      faqs: [
+        {
+          q: "Apa itu penampil negatif film?",
+          a: "Ini adalah alat yang membalikkan warna negatif film untuk menampilkan foto asli sebagai positif. Secara tradisional Anda memerlukan lightbox dan loupe; alat online menggunakan kamera perangkat dan inversi perangkat lunak untuk menampilkan positif secara real-time.",
+        },
+        {
+          q: "Apakah Negative Viewer benar-benar gratis?",
+          a: "Ya. Situs ini gratis sejak diluncurkan, tidak perlu akun, tanpa uji coba, tanpa biaya per gambar. Iklan ringan mendukung biaya hosting.",
+        },
+        {
+          q: "Apakah situs mengunggah video atau foto kamera saya?",
+          a: "Tidak. Setiap bingkai diproses secara lokal di browser melalui HTML Canvas API. Aliran video tidak pernah meninggalkan perangkat Anda.",
+        },
+        {
+          q: "Format film apa yang didukung?",
+          a: "Setiap negatif yang bisa disinari dari belakang, termasuk 35mm warna dan hitam putih, 120, 4×5 dan 8×10, APS, Disc, dan 110.",
+        },
+        {
+          q: "Apakah bisa untuk film slide atau positif?",
+          a: "Film slide sudah berupa positif. Membalikkannya akan membuatnya tampak seperti negatif, jadi mode ini biasanya tidak diperlukan untuk slide.",
+        },
+        {
+          q: "Mengapa pratinjau terlihat kebiruan atau sian?",
+          a: "Film warna memiliki dasar oranye, yang setelah inversi menghasilkan semburat biru ringan. Ini normal dan bisa disesuaikan dengan white balance di editor foto apa pun.",
+        },
+        {
+          q: "Cahaya seperti apa yang harus digunakan?",
+          a: "Cahaya putih, terang, dan merata adalah yang terbaik. Pilihan umum: layar ponsel atau tablet yang menampilkan putih, lightbox kecil, lampu meja dengan kertas difusi, atau cahaya jendela saat mendung.",
+        },
+        {
+          q: "Mengapa kamera tidak mau mulai?",
+          a: "Tiga alasan umum: sebelumnya menolak izin kamera, berada di browser bawaan aplikasi, atau tidak menggunakan HTTPS.",
+        },
+        {
+          q: "Bagaimana cara menyimpan foto?",
+          a: "Saat kamera berjalan, tekan tombol simpan foto. Browser mengunduh pratinjau saat ini sebagai PNG.",
+        },
+        {
+          q: "Bisa memproses seluruh rol sekaligus?",
+          a: "Bisa secara manual. Bentangkan seluruh strip di atas cahaya latar, geser setiap bingkai ke dalam tampilan, dan tekan simpan foto.",
+        },
+        {
+          q: "Bisa memproses file negatif yang sudah difoto atau dipindai?",
+          a: "Ya. Negative Viewer paling cocok untuk pratinjau langsung lewat kamera. Jika Anda sudah punya file gambar, buka Negative Converter untuk mengonversi dan mengekspor positif.",
+        },
+        {
+          q: "Bagaimana dibandingkan dengan kurva inversi di Lightroom?",
+          a: "Lightroom atau alur kerja RAW lebih cocok untuk hasil akhir, karena memproses foto diam dengan kedalaman bit tinggi. Negative Viewer jauh lebih cepat — Anda melihat positif saat masih melihat negatifnya, bagus untuk menyortir gulungan yang belum diketahui.",
+        },
+        {
+          q: "Bisa digunakan di Chromebook atau iPad?",
+          a: "Ya. Selama perangkat memiliki kamera yang berfungsi dan mendukung API getUserMedia, Chromebook, iPad, ponsel, dan tablet semuanya bisa.",
+        },
+        {
+          q: "Bagaimana orientasi negatif yang benar?",
+          a: "Biasanya sisi emulsi yang lebih buram menghadap kamera, sisi mengkilap menghadap cahaya latar. Jika pratinjau terbalik, coba sisi sebaliknya.",
+        },
+        {
+          q: "Apakah fitur baru akan dikenakan biaya?",
+          a: "Penampil inti akan tetap gratis. Penambahan di masa depan seperti penghilangan dasar oranye yang lebih baik atau koreksi perspektif juga akan mengutamakan implementasi sisi klien.",
+        },
+        {
+          q: "Saya punya masukan atau saran, ke mana mengirimnya?",
+          a: "Cara tercepat adalah membuka issue di repositori GitHub yang ditautkan di halaman Tentang. Setiap masukan dibaca.",
+        },
+      ],
+    },
+    about: {
+      metaTitle: "Tentang Negative Viewer - Alat Negatif Film Online yang Menjaga Privasi",
+      metaDescription:
+        "Pelajari tentang Negative Viewer: mengapa ada, cara kerjanya, komitmen privasi, dan teknologi di balik pengonversi negatif film berbasis browser ini.",
+      title: "Tentang Negative Viewer",
+      sections: [
+        {
+          title: "Mengapa alat ini ada",
+          paragraphs: [
+            "Banyak orang memiliki negatif film tetapi tidak memiliki pemindai film. Pemindai khusus mahal, setiap pemindaian butuh waktu, dan seringkali hanya digunakan beberapa kali setahun. Sementara itu, ponsel di saku Anda sudah memiliki kamera yang cukup baik untuk melihat pratinjau negatif — hanya kurang perangkat lunak untuk membalikkan gambar secara real-time.",
+            "Negative Viewer adalah perangkat lunak itu. Berjalan sebagai aplikasi web kecil sehingga tidak perlu instalasi. Letakkan negatif di atas cahaya latar apa pun, arahkan ponsel, dan gambar positif muncul di layar.",
+          ],
+        },
+        {
+          title: "Cara kerjanya",
+          paragraphs: [
+            "Alat ini meminta izin kamera melalui Web getUserMedia API standar. Setiap bingkai video digambar ke HTML Canvas, mengurangi saluran merah, hijau, biru dari 255 — inversi warna standar — lalu menggambarnya kembali ke layar pada kecepatan bingkai kamera.",
+            "Tidak ada jaringan saraf, tidak ada pemrosesan cloud, tidak ada unggahan. Kode intinya kecil dan seluruh sumber tersimpan di repositori proyek.",
+          ],
+        },
+        {
+          title: "Komitmen privasi",
+          list: [
+            "Tidak ada unggahan aliran kamera. Piksel hanya diproses di browser Anda dan situs tidak memiliki endpoint yang menerima data video atau foto.",
+            "Tidak diperlukan akun, email, atau sidik jari. Kami hanya mengumpulkan analitik halaman anonim untuk memutuskan apa yang perlu ditingkatkan.",
+            "Iklan ditampilkan dengan jelas. Situs menggunakan Google AdSense; kontrol iklan tersedia di Google Ad Settings.",
+          ],
+        },
+        {
+          title: "Siapa yang memelihara",
+          paragraphs: [
+            "Negative Viewer dibuat dan dipelihara oleh seorang pengembang di Tokugai. Proyek ini dimulai hanya untuk menyortir sekotak negatif keluarga dan menjadi situs publik setelah disarankan oleh teman-teman.",
+          ],
+        },
+        {
+          title: "Rencana pengembangan",
+          list: [
+            "Penghilangan dasar oranye film warna opsional dalam browser.",
+            "Pangkas dan putar sebelum menyimpan agar PNG lebih siap dibagikan.",
+            "Opsi ekspor bersih EXIF untuk arsip sensitif.",
+          ],
+        },
+      ],
+      cta: {
+        text: "Siap?",
+        link: "Buka penampil →",
+      },
+    },
+    guides: {
+      filmNegatives: {
+        metaTitle: "Penjelasan Negatif Film: Cara Kerja, Identifikasi, dan Melihatnya",
+        metaDescription:
+          "Panduan praktis tentang negatif film: mengapa berwarna oranye, cara membedakan 35mm/120/lembar, cara membaca bingkai, dan melihat positif tanpa pemindai.",
+        title: "Penjelasan Negatif Film: Cara Kerja dan Cara Melihatnya",
+        readTime: "6 menit",
+        intro:
+          "Negatif film adalah lembaran plastik transparan yang merekam adegan secara terbalik: area terang menjadi gelap, warna berubah menjadi komplemennya. Untuk melihat foto sebenarnya, gambar perlu dibalik.",
+        sections: [
+          {
+            title: "Apa itu negatif",
+            paragraphs: [
+              "Negatif terdiri dari emulsi peka cahaya pada dasar plastik. Setelah diproses, bagian terang dari adegan menjadi lebih padat, bayangan lebih transparan.",
+              "Negatif adalah master. Anda bisa mencetak atau memindainya berkali-kali, mengubah potongan, kontras, dan warna setiap kali.",
+            ],
+          },
+          {
+            title: "Mengapa film warna berwarna oranye",
+            paragraphs: [
+              "Dasar oranye adalah topeng warna, mengkompensasi ketidaksempurnaan pewarna film saat pencetakan optik. Saat dibalik secara digital, biasanya meninggalkan semburat biru ringan.",
+            ],
+            list: [
+              "Negatif warna biasanya perlu penyesuaian white balance setelah inversi.",
+              "Negatif hitam putih tidak memiliki topeng oranye.",
+              "Film slide/positif sudah berupa positif, tidak perlu inversi.",
+            ],
+          },
+          {
+            title: "Format umum",
+            table: {
+              headers: ["Format", "Ukuran bingkai", "Penggunaan umum"],
+              rows: [
+                ["35mm", "24 × 36 mm", "Kamera keluarga dan penggemar film modern"],
+                ["120", "6×4.5 hingga 6×9", "Potret, pernikahan, studio"],
+                ["4×5", "102 × 127 mm", "Lanskap dan arsitektur"],
+                ["APS / 110", "Lebih kecil dari 35mm", "Kamera saku"],
+              ],
+            },
+          },
+          {
+            title: "Cara melihat positif dengan biaya rendah",
+            table: {
+              headers: ["Metode", "Biaya", "Paling cocok untuk"],
+              rows: [
+                ["Negative Viewer + layar ponsel", "Gratis", "Pratinjau cepat dan pemilahan"],
+                ["Foto ponsel + inversi di aplikasi", "Gratis", "Gambar untuk dikirim dan dibagikan"],
+                ["Kamera + lensa makro + lightbox", "Biaya rendah jika sudah punya peralatan", "Kualitas arsip"],
+                ["Pemindai datar", "$250–$400", "Batch dan format menengah"],
+              ],
+            },
+          },
+          {
+            title: "Menyimpan negatif",
+            list: [
+              "Simpan film di tempat sejuk, kering, dan gelap.",
+              "Gunakan kantong arsip polietilen, polipropilen, atau poliester.",
+              "Hanya sentuh bagian tepi film untuk menghindari goresan emulsi.",
+            ],
+          },
+        ],
+        cta: {
+          text: "Coba dengan negatif Anda:",
+          link: "Buka penampil →",
+        },
+      },
+      digitize35mm: {
+        metaTitle: "Cara Mendigitalisasi Negatif Film 35mm di Rumah",
+        metaDescription:
+          "Bandingkan empat cara mendigitalisasi negatif 35mm di rumah: pratinjau browser, foto ponsel lalu balik, pemindaian DSLR, dan pemindai datar.",
+        title: "Cara Mendigitalisasi Film 35mm di Rumah",
+        readTime: "6 menit",
+        intro:
+          "Cara tercepat untuk mengetahui isi gulungan lama adalah membuka penampil browser. Untuk kualitas lebih baik, ambil foto diam resolusi penuh dengan ponsel atau kamera dengan lensa makro.",
+        sections: [
+          {
+            title: "Pilihan cepat",
+            table: {
+              headers: ["Tujuan", "Metode", "Alasan"],
+              rows: [
+                ["Hanya ingin melihat isinya", "Penampil browser", "Instan, gratis, tanpa pengaturan"],
+                ["Berbagi foto keluarga", "Foto ponsel + inversi", "Cukup baik untuk layar"],
+                ["Kualitas arsip", "Pemindaian DSLR / mirrorless", "RAW dan detail tinggi"],
+                ["Ratusan bingkai", "Pemindai datar", "Pemegang film dan alur batch"],
+              ],
+            },
+          },
+          {
+            title: "Metode 1 — Penampil browser",
+            paragraphs: [
+              "Letakkan negatif di atas cahaya latar merata, izinkan kamera, dan lihat positif secara real-time. Ini cara terbaik untuk memilah seluruh rol dengan cepat.",
+            ],
+          },
+          {
+            title: "Metode 2 — Foto ponsel",
+            paragraphs: [
+              "Ambil foto negatif yang disinari pada resolusi penuh ponsel, lalu balikkan di Snapseed, Lightroom Mobile, atau editor lain. Kualitas biasanya lebih tinggi dari bingkai video.",
+            ],
+          },
+          {
+            title: "Metode 3 — Kamera dan lensa makro",
+            paragraphs: [
+              "Kamera digital pada tripod atau dudukan salin memberikan hasil terbaik. Ambil RAW, kunci white balance, dan balikkan di editor.",
+            ],
+          },
+          {
+            title: "Tips umum",
+            list: [
+              "Bersihkan film sebelum memotret.",
+              "Jaga kamera dan film sejajar.",
+              "Gunakan sumber cahaya dengan rendering warna yang baik.",
+              "Simpan PNG atau TIFF sebagai file master.",
+            ],
+          },
+        ],
+        cta: {
+          text: "Mau mulai dengan yang gratis?",
+          link: "Buka Negative Viewer →",
+        },
+      },
+      filmVsDigital: {
+        metaTitle: "Film vs. Fotografi Digital: Perbandingan Praktis",
+        metaDescription:
+          "Membandingkan film dan fotografi digital pada resolusi, rentang dinamis, biaya per foto, umur arsip, dan apa yang disebut 'look film'.",
+        title: "Film vs. Fotografi Digital: Perbandingan Praktis",
+        readTime: "5 menit",
+        intro:
+          "Kamera digital modern biasanya menang dalam kenyamanan dan biaya per foto, tetapi film tetap memiliki nilai: negatif asli yang tahan lama, tekstur grain, dan ritme pemotretan yang disengaja dari jumlah bingkai terbatas.",
+        sections: [
+          {
+            title: "Kesimpulan cepat",
+            table: {
+              headers: ["Situasi", "Saran", "Alasan"],
+              rows: [
+                ["Belajar dan memotret harian", "Digital", "Umpan balik instan, biaya per foto hampir nol"],
+                ["Pernikahan dan acara", "Digital", "Andal, pengiriman cepat"],
+                ["Potret dan editorial", "Keduanya", "Film untuk gaya, digital untuk anggaran"],
+                ["Arsip keluarga jangka panjang", "Negatif + salinan digital", "Negatif tahan lama, digital mudah dibagikan"],
+              ],
+            },
+          },
+          {
+            title: "Resolusi dan rentang dinamis",
+            paragraphs: [
+              "Negatif warna 35mm biasanya menghasilkan sekitar 12–18 MP detail berguna saat dipindai dengan baik. Format menengah dan besar bisa jauh melampaui itu.",
+              "Negatif warna toleran terhadap overexposure, tetapi sensor digital modern telah menyamai atau melampaui rentang dinamis banyak alur kerja film.",
+            ],
+          },
+          {
+            title: "Biaya per foto",
+            paragraphs: [
+              "Kamera digital mahal di awal tetapi kemudian setiap foto hampir gratis. Film lebih murah untuk memulai tetapi film, pemrosesan, dan pemindaian terus menambah biaya.",
+            ],
+          },
+          {
+            title: "Mengapa masih memotret dengan film",
+            list: [
+              "Grain dan transisi tonal berbeda dari noise digital.",
+              "Jumlah bingkai terbatas memaksa Anda berpikir sebelum memotret.",
+              "Negatif adalah artefak fisik yang bisa disimpan selama puluhan tahun.",
+            ],
+          },
+        ],
+        cta: {
+          text: "Memotret dengan film?",
+          link: "Buka Negative Viewer →",
+        },
+      },
+    },
+  },
 };
 
 export function getLocalizedPage(locale, page) {


### PR DESCRIPTION
## Summary

Adds full Vietnamese (Tiếng Việt) and Indonesian (Bahasa Indonesia) language support to Negative Viewer.

## Changes

- **`lib/i18n.js`**: Added `vi` and `id` to `translatedLocales` array, `localeOptions`, and complete UI dictionary translations for both languages (navigation, footer, viewer strings)
- **`lib/localized-content.js`**: Added complete localized page content for both languages covering:
  - Home page (hero, features, steps, FAQs, etc.)
  - How-to-use guide
  - FAQ page
  - About page
  - All three guides (film negatives, digitize 35mm, film vs digital)

## Verification

- `next build` succeeds with all 8 translated locales generating correctly
- All route paths are properly generated for vi and id locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)